### PR TITLE
allow dot access to an Indifferent Hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ A simple indifferent access proxy:
     h = {'foo'=>{bar: 2}}
     w = HashTools.indifferent(h)
     w[:foo][:bar] #=> 2
+    w.foo.bar #=> 2
 
 Check the documentation for the separate modules for more.
 

--- a/lib/hash_tools/indifferent.rb
+++ b/lib/hash_tools/indifferent.rb
@@ -82,13 +82,13 @@ class HashTools::Indifferent < SimpleDelegator
     end
   end
   
-  def method_missing(method, *opts)
-    m = method.to_s
-    if self.key?(m)
-      return self[m]
-    elsif self.key?(m.to_sym)
-      return self[m.to_sym]
-    end
+  def method_missing(method_name, *args)
+    return self[method_name] if key?(method_name) && args.empty?
+    super
+  end
+  
+  def respond_to_missing?(method_name)
+    key?(method_name)
   end
   
   alias_method :has_key?, :key?

--- a/lib/hash_tools/indifferent.rb
+++ b/lib/hash_tools/indifferent.rb
@@ -82,6 +82,15 @@ class HashTools::Indifferent < SimpleDelegator
     end
   end
   
+  def method_missing(method, *opts)
+    m = method.to_s
+    if self.key?(m)
+      return self[m]
+    elsif self.key?(m.to_sym)
+      return self[m.to_sym]
+    end
+  end
+  
   alias_method :has_key?, :key?
   
   private

--- a/spec/hash_tools/indifferent_spec.rb
+++ b/spec/hash_tools/indifferent_spec.rb
@@ -15,6 +15,9 @@ describe HashTools::Indifferent do
     expect(wrapper.fetch('b')).to eq(2)
     expect(wrapper.fetch(:b)).to eq(2)
     
+    expect(wrapper.a).to eq(1)
+    expect(wrapper.b).to eq(2)
+    
     expect(wrapper.keys).to eq(h_syms.keys)
   end
   
@@ -27,6 +30,9 @@ describe HashTools::Indifferent do
     
     expect(wrapper[:a][:c]).to eq(2)
     expect(wrapper['a']['c']).to eq(2)
+    
+    expect(wrapper.a.b).to eq(1)
+    expect(wrapper.a.c).to eq(2)
     
     expect(wrapper.keys).to eq(h_deep.keys)
   end

--- a/spec/hash_tools/indifferent_spec.rb
+++ b/spec/hash_tools/indifferent_spec.rb
@@ -21,6 +21,15 @@ describe HashTools::Indifferent do
     expect(wrapper.keys).to eq(h_syms.keys)
   end
   
+  it 'raises NoMethodError when accessing missing keys via dot notation' do
+    h_syms = {a: 1, 'b' => 2}
+    wrapper = described_class.new(h_syms)
+    
+    expect {
+      wrapper.c
+    }.to raise_error(NoMethodError)
+  end
+  
   it 'supports indifferent access to deeply nested hashes' do
     h_deep = {a: {:b => 1, 'c' => 2}}
     


### PR DESCRIPTION
Now you can do:

x = HashTools.indifferent({ a: ‘b’ })
x.a #> ‘b’